### PR TITLE
Fixing npm publish

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -28,6 +28,6 @@ jobs:
       - run: yarn install --pure-lockfile
       - run: yarn build
       - run: yarn prepare-publish
-      - run: npm publish dist/src
+      - run: npm publish dist/src --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [x] Infrastructure changes

## Description
The npm package was trying to publish as a private package, which our account does not support. From the [npm docs](https://docs.npmjs.com/creating-and-publishing-an-org-scoped-package):

> By default, any scoped package is published as private. However, if you have an Org that does not have the Private Packages feature, npm publish will fail unless you pass the access flag.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path. -->