### PR TITLE
Restructure package exports

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,5 +22,6 @@ jobs:
         yarn install --pure-lockfile
         yarn build
         yarn test
+        yarn lint
       env:
         CI: true

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "npx tslint -p tsconfig.json",
     "build": "npx tsc",
-    "prepare-publish": "cp package.json dist/src/package.json",
+    "prepare-publish": "cp ./{package.json,readme.md} dist/src/",
     "test": "mocha \"dist/test/unit/**/*.js\" --reporter spec",
     "test:e2e": "mocha \"dist/test/integration/**/*.js\" --reporter spec"
   },

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Navo Warehouse JS Client [![Build Status](https://travis-ci.org/navoio/warehouse-js.svg?branch=master)](https://travis-ci.org/navoio/warehouse-js)
+# Navo Warehouse JS Client [![Actions Status](https://github.com/navoio/warehouse-js/workflows/Node%20CI/badge.svg)](https://github.com/navoio/warehouse-js/actions)
 JavaScript and Node client for accessing [Navo Warehouse](https://navo.io/products/warehouse/) data.
 
 ## Install
@@ -10,14 +10,14 @@ npm install @navoio/warehouse
 
 ## Authentication
 ```js
-import Navo from '@navoio/warehouse';
+import { NavoClient } from '@navoio/warehouse';
 
 // Option 1- pass credentials into constructor
-const client = new Navo(apiUrl, 'username', 'password');
+const client = new NavoClient(apiUrl, 'client-id', 'api-key');
 
 // Option 2- call authorize() manually
-const client = new Navo(apiUrl);
-client.authorize('username', 'password');
+const client = new NavoClient(apiUrl);
+client.authorize('client-id', 'api-key');
 ```
 
 ## Jobs

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,59 @@
+import { AxiosInstance } from 'axios';
+import base from './axios-base';
+import { JobsClient } from './jobs';
+
+/**
+ * Navo Client for interfacing with a Navo server.
+ */
+export class NavoClient {
+    /** Base URL of Navo API */
+    public url: string;
+    /** Client ID */
+    public clientId: string;
+    /** API private key */
+    public apiKey: string;
+    /** Server-generated authorization token */
+    public token: string;
+    /** Namespace for accessing Navo jobs */
+    public jobs: JobsClient;
+    public axios: AxiosInstance;
+
+    /**
+     * Navo client constructor
+     * @param url Base path of the Navo API
+     * @param credentials API credentials
+     */
+    constructor(url: string, credentials?: { clientId: string, apiKey: string }) {
+        this.url = url;
+        if (credentials) {
+            this.clientId = credentials.clientId;
+            this.apiKey = credentials.apiKey;
+        }
+        this.token = '';
+        this.axios = base(url);
+        this.jobs = new JobsClient(this.axios, this);
+    }
+
+    /**
+     * Authenticates Navo API client
+     * @param clientId Client ID
+     * @param apiKey Private API key
+     */
+    public authenticate(clientId: string, apiKey: string): Promise<NavoClient> {
+        const client: NavoClient = this;
+        return client.axios.post('token', {
+            clientId,
+            apiKey
+        })
+            .then(response => {
+                const token: string = response.data.token;
+                client.token = token;
+                return client;
+            });
+    }
+
+    public authorizeIfNeeded() {
+        if (this.token) { return Promise.resolve(this); }
+        return this.authenticate(this.clientId, this.apiKey);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,54 +1,5 @@
-import { AxiosInstance } from 'axios';
-import base from './axios-base';
-import JobsClient from './jobs';
+import { NavoClient } from './client';
 
-/**
- * Navo Client for interfacing with a Navo server.
- */
-export default class NavoClient {
-    public url: string;
-    public username: string;
-    public password: string;
-    public token: string;
-    public jobs: JobsClient;
-    public axios: AxiosInstance;
-
-    /**
-     * Navo client constructor
-     * @param url Base path of the Navo API
-     * @param credentials API credentials
-     */
-    constructor(url: string, credentials?: { username: string, password: string }) {
-        this.url = url;
-        if (credentials) {
-            this.username = credentials.username;
-            this.password = credentials.password;
-        }
-        this.token = '';
-        this.axios = base(url);
-        this.jobs = new JobsClient(this.axios, this);
-    }
-
-    /**
-     * Authorize Navo API user
-     * @param username
-     * @param password
-     */
-    public authorize(username: string, password: string): Promise<NavoClient> {
-        const client: NavoClient = this;
-        return client.axios.post('token', {
-            username,
-            password
-        })
-            .then(response => {
-                const token: string = response.data.token;
-                client.token = token;
-                return client;
-            });
-    }
-
-    public authorizeIfNeeded() {
-        if (this.token) { return Promise.resolve(this); }
-        return this.authorize(this.username, this.password);
-    }
-}
+export {
+    NavoClient
+};

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -1,8 +1,8 @@
 import { AxiosInstance } from 'axios';
-import NavoClient from '.';
+import { NavoClient } from './client';
 import { Job } from './job';
 
-export default class JobsClient {
+export class JobsClient {
     public baseClient: NavoClient;
     private axios: AxiosInstance;
 

--- a/test/integration/index.ts
+++ b/test/integration/index.ts
@@ -1,12 +1,12 @@
 import chai from 'chai';
-import NavoClient from '../../src';
+import { NavoClient } from '../../src';
 const expect = chai.expect;
 const apiUrl = 'https://my.navo.io/api';
 
-describe('NavoClient authorize()', () => {
-    it('should return a token', async () => {
+describe('NavoClient authenticate()', () => {
+    it('should set a token', async () => {
         const client = new NavoClient(apiUrl);
-        await client.authorize('TEST', 'TEST123');
-        expect(client.token).to.be.ok;
+        await client.authenticate('TEST', 'TEST123');
+        return expect(client.token).to.be.ok;
     });
 });

--- a/test/integration/index.ts
+++ b/test/integration/index.ts
@@ -1,12 +1,26 @@
 import chai from 'chai';
+import { AxiosError } from 'axios';
 import { NavoClient } from '../../src';
 const expect = chai.expect;
 const apiUrl = 'https://my.navo.io/api';
+const credentials = {
+    clientId: 'client',
+    apiKey: 'api-key'
+}
 
 describe('NavoClient authenticate()', () => {
     it('should set a token', async () => {
         const client = new NavoClient(apiUrl);
-        await client.authenticate('TEST', 'TEST123');
+        await client.authenticate(credentials.clientId, credentials.apiKey);
         return expect(client.token).to.be.ok;
+    });
+
+    it('should return a 400 error with invalid credentials', async () => {
+        const client = new NavoClient(apiUrl);
+        try {
+            await client.authenticate(credentials.clientId, '')
+        } catch (error) {
+            return expect((error as AxiosError).response?.status).to.equal(400);
+        }
     });
 });

--- a/test/integration/index.ts
+++ b/test/integration/index.ts
@@ -1,12 +1,12 @@
-import chai from 'chai';
 import { AxiosError } from 'axios';
+import chai from 'chai';
 import { NavoClient } from '../../src';
 const expect = chai.expect;
 const apiUrl = 'https://my.navo.io/api';
 const credentials = {
     clientId: 'client',
     apiKey: 'api-key'
-}
+};
 
 describe('NavoClient authenticate()', () => {
     it('should set a token', async () => {
@@ -18,7 +18,7 @@ describe('NavoClient authenticate()', () => {
     it('should return a 400 error with invalid credentials', async () => {
         const client = new NavoClient(apiUrl);
         try {
-            await client.authenticate(credentials.clientId, '')
+            await client.authenticate(credentials.clientId, '');
         } catch (error) {
             return expect((error as AxiosError).response?.status).to.equal(400);
         }

--- a/test/unit/auth.ts
+++ b/test/unit/auth.ts
@@ -15,4 +15,3 @@ describe('Navo Client', () => {
         return expect(client.token).to.be.ok;
     });
 });
-c

--- a/test/unit/auth.ts
+++ b/test/unit/auth.ts
@@ -1,7 +1,5 @@
 import chai from 'chai';
-import nock from 'nock';
-import NavoClient from '../../src';
-import { Job, JobStatus } from '../../src/job';
+import { NavoClient } from '../../src';
 import * as authNocks from './responses/auth';
 import * as jobNocks from './responses/jobs';
 const expect = chai.expect;
@@ -12,8 +10,9 @@ describe('Navo Client', () => {
     it('should get auth token on demand when constructed with credentials', async () => {
         authNocks.successfulAuth(apiDomain);
         jobNocks.getJobSuccess(apiDomain);
-        const client = new NavoClient(apiLocation, { username: 'test-user', password: 'fake-password' });
-        const job = await client.jobs.get(1);
-        expect(client.token).to.be.ok;
+        const client = new NavoClient(apiLocation, { clientId: 'test-user', apiKey: 'fake-key' });
+        await client.jobs.get(1);
+        return expect(client.token).to.be.ok;
     });
 });
+c

--- a/test/unit/jobs.ts
+++ b/test/unit/jobs.ts
@@ -1,5 +1,5 @@
 import chai from 'chai';
-import NavoClient from '../../src';
+import { NavoClient } from '../../src';
 import * as authNocks from './responses/auth';
 import * as jobNocks from './responses/jobs';
 const expect = chai.expect;
@@ -11,16 +11,16 @@ describe('Navo Jobs Client', () => {
     it('should return an individual job', async () => {
         authNocks.successfulAuth(apiDomain);
         jobNocks.getJobSuccess(apiDomain);
-        const client = new NavoClient(apiLocation, { username: 'test-user', password: 'fake-password' });
+        const client = new NavoClient(apiLocation, { clientId: 'client-id', apiKey: 'api-key' });
         const job = await client.jobs.get(1);
-        expect(job).to.be.ok;
+        return expect(job).to.be.ok;
     });
 
     it('should return all active jobs', async () => {
         authNocks.successfulAuth(apiDomain);
         jobNocks.getJobsSuccess(apiDomain);
-        const client = new NavoClient(apiLocation, { username: 'test-user', password: 'fake-password' });
+        const client = new NavoClient(apiLocation, { clientId: 'client-id', apiKey: 'api-key' });
         const jobs = await client.jobs.getAll();
-        expect(jobs.length).to.be.greaterThan(0);
+        return expect(jobs.length).to.be.greaterThan(0);
     });
 });

--- a/test/unit/responses/auth.ts
+++ b/test/unit/responses/auth.ts
@@ -3,7 +3,7 @@ import nock from 'nock';
 function badPassword(apiUrl: string) {
     return nock(apiUrl)
         .post('/api/token')
-        .reply(400, 'Invalid username or password.');
+        .reply(400, 'Invalid client ID or private key.');
 }
 
 function successfulAuth(apiHost: string) {

--- a/utilities/nock-recorder.ts
+++ b/utilities/nock-recorder.ts
@@ -1,19 +1,19 @@
-import NavoClient from '../src';
+import { NavoClient } from '../src';
 import nock from 'nock';
 const apiUrl = 'http://localhost:59626';
-const username = 'TESTUSER',
-    password = 'TESTUSER-PASSWORD';
+const clientId = 'TEST-USER',
+    apiKey = 'TEST-USER-Key';
 
-function getJob(){
-    let client = new NavoClient(apiUrl, username, password);
+function getJob() {
+    let client = new NavoClient(apiUrl, { clientId, apiKey });
     return client.jobs.get(1)
         .then(job => {
             console.log(job);
         });
 }
 
-function getJobs(){
-    let client = new NavoClient(apiUrl, username, password);
+function getJobs() {
+    let client = new NavoClient(apiUrl, { clientId, apiKey });
     return client.jobs.getAll()
         .then(jobs => {
             console.log(jobs);


### PR DESCRIPTION
## Description
Root package export is now named exports instead of a default export. This makes it identical to use in both CommonJS module and ES6 module environments. This gives the package more flexibility (without breaking changes) for future enhancements.
```ts
// previous usage (before this PR)
import NavoClient from '@navoio/warehouse`;
// with this latest PR, usage changes to
import { NavoClient } from '@navoio/warehouse`;
```
Other changes:
- Added readme to package (for npm repo browsing).
- Added linter to CI checks.
- Changed build badge from Travis to GitHub Actions.
- Added e2e test to verify exception when credentials are invalid.

